### PR TITLE
Feat : 채팅 DB 연결

### DIFF
--- a/chat/src/main/java/pnu/cse/studyhub/chat/exception/ErrorCode.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/exception/ErrorCode.java
@@ -1,0 +1,41 @@
+package pnu.cse.studyhub.chat.exception;
+
+
+import pnu.cse.studyhub.chat.dto.response.ErrorResponse;
+
+import java.time.LocalDate;
+
+public enum ErrorCode {
+    INVALID_TOKEN(401, "AUTH-001", "토큰이 유효하지 않은 경우"),
+    EXPIRED_TOKEN(401, "AUTH-002", "토큰이 만료된 경우"),
+    MISSING_TOKEN(401, "AUTH-003", "토큰을 전달하지 않은 경우"),
+    INCORRECT_TOKEN(401, "AUTH-004", "허용된 토큰이 아닌 경우"),
+    NOT_ACCESS_TOKEN(400, "AUTH-005", "액세스 토큰이 아닌 경우"),
+    NOT_EXISTED_REFRESH_TOKEN(404, "AUTH-006", "저장된 리프레쉬 토큰이 없는 경우"),
+    UNAUTHORIZED(401, "AUTH-007", "인증에 실패한 경우"),
+    WITHDRAWAL_USER(403, "AUTH-008", "탈퇴한 회원이 요청한 경우"),
+    PASSWORD_NOT_CHANGED(400, "AUTH-009", "새 비밀번호로 바꿀 수 없는 경우"),
+    INCORRECT_PASSWORD(401, "AUTH-010", "비밀번호가 일치하지 않는 경우"),
+    INCORRECT_VERIFICATION_CODE(401, "AUTH-011", "이메일 인증 코드가 틀린 경우"),
+    USER_NOT_FOUND(404, "USER-001", "해당 유저가 존재하지 않는 경우"),
+    DUPLICATION_USER(409,"USER-002","해당 유저가 이미 존재하는 경우"); //409 confilct
+
+    private final int status;
+    private final String code;
+    private final String description;
+
+    ErrorCode(int status, String code, String description) {
+        this.status = status;
+        this.code = code;
+        this.description = description;
+    }
+    public ErrorResponse toErrorResponseDto(String msg) {
+        return ErrorResponse
+                .builder()
+                .status(this.status)
+                .errorCode(this.code)
+                .timestamp(LocalDate.now())
+                .message(msg)
+                .build();
+    }
+}

--- a/chat/src/main/java/pnu/cse/studyhub/chat/exception/ExamplelException.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/exception/ExamplelException.java
@@ -1,0 +1,7 @@
+package pnu.cse.studyhub.chat.exception;
+
+public class ExamplelException extends RuntimeException {
+    public ExamplelException(String msg) {
+        super(msg);
+    }
+}

--- a/chat/src/main/java/pnu/cse/studyhub/chat/exception/GlobalExceptionHandler.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/exception/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+//package pnu.cse.studyhub.chat.exception;
+//
+//import io.jsonwebtoken.ExpiredJwtException;
+//import io.jsonwebtoken.MalformedJwtException;
+//import io.jsonwebtoken.SignatureException;
+//import io.jsonwebtoken.UnsupportedJwtException;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.ControllerAdvice;
+//import org.springframework.web.bind.annotation.ExceptionHandler;
+//import org.springframework.web.bind.annotation.RestController;
+//import smilegate.plop.auth.dto.response.ErrorResponseDto;
+//
+//@RestController
+//@ControllerAdvice
+//public class GlobalExceptionHandler {
+//    @ExceptionHandler(UserNotFoundException.class)
+//    public ResponseEntity<ErrorResponseDto> handleUserNotFoundException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.USER_NOT_FOUND.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponseDto);
+//    }
+//    @ExceptionHandler(DuplicateUserException.class)
+//    public ResponseEntity<ErrorResponseDto> handleDuplicateUserException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.DUPLICATION_USER.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponseDto);
+//    }
+//    @ExceptionHandler(WithdrawalUserException.class)
+//    public ResponseEntity<ErrorResponseDto> handleWithdrawalUserException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.WITHDRAWAL_USER.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponseDto);
+//    }
+//    @ExceptionHandler(IncorrectPasswordException.class)
+//    public ResponseEntity<ErrorResponseDto> handleIncorrectPasswordException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.INCORRECT_PASSWORD.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponseDto);
+//    }
+//    @ExceptionHandler(NotAccessTokenException.class)
+//    public ResponseEntity<ErrorResponseDto> handleAccessTokenException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.NOT_ACCESS_TOKEN.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponseDto);
+//    }
+//    @ExceptionHandler(RedisNullException.class)
+//    public ResponseEntity<ErrorResponseDto> handleRedisNullException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.NOT_EXISTED_REFRESH_TOKEN.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponseDto);
+//    }
+//    @ExceptionHandler(PasswordNotChangedException.class)
+//    public ResponseEntity<ErrorResponseDto> handlePasswordNotChangedException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.PASSWORD_NOT_CHANGED.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponseDto);
+//    }@ExceptionHandler(IncorrectVerificationCodeException.class)
+//    public ResponseEntity<ErrorResponseDto> handleVerificationCodeException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.INCORRECT_VERIFICATION_CODE.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponseDto);
+//    }
+//    @ExceptionHandler({SignatureException.class, MalformedJwtException.class,
+//            UnsupportedJwtException.class,IllegalArgumentException.class, ExpiredJwtException.class
+//    })
+//    public ResponseEntity<ErrorResponseDto> handleJwtException(Exception e) {
+//        ErrorResponseDto errorResponseDto = ErrorCode.INCORRECT_TOKEN.toErrorResponseDto(e.getMessage());
+//        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponseDto);
+//    }
+//}

--- a/chat/src/main/java/pnu/cse/studyhub/chat/repository/ChatRepository.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/repository/ChatRepository.java
@@ -1,0 +1,8 @@
+package pnu.cse.studyhub.chat.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import pnu.cse.studyhub.chat.repository.entity.Chat;
+
+public interface ChatRepository extends MongoRepository<Chat,String> {
+
+}

--- a/chat/src/main/java/pnu/cse/studyhub/chat/service/ChatService.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/service/ChatService.java
@@ -1,0 +1,22 @@
+package pnu.cse.studyhub.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import pnu.cse.studyhub.chat.dto.request.ChatRequest;
+import pnu.cse.studyhub.chat.repository.ChatRepository;
+import pnu.cse.studyhub.chat.repository.entity.Chat;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+
+    public Chat saveChat(ChatRequest chatRequest){
+        Chat chatEntity = chatRequest.toEntity();
+        Chat savedChat = chatRepository.save(chatEntity);
+        return savedChat;
+    }
+}

--- a/chat/src/main/resources/application.yml
+++ b/chat/src/main/resources/application.yml
@@ -5,15 +5,20 @@ server:
 spring:
   application:
     name: chat-service
+  data:
+    mongodb:
+      uri: mongodb+srv://studyhub_admin:pnucse@studyhub.iyncwyz.mongodb.net/studyhub?retryWrites=true&w=majority
   kafka:
     producer:
       bootstrap-servers: localhost:9092
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+#      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
       bootstrap-servers: localhost:9092
       key-serializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+#      value-serializer: org.springframework.kafka.support.serializer.JsonDeserializer
       group-id: pnu-cse
     topic : studyhub
     pub-topic-name: send
@@ -43,3 +48,7 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://127.0.0.1:8761/eureka
+
+logging:
+  level:
+    pnu.cse.studyhub: DEBUG


### PR DESCRIPTION
## 개요

#7  - roomID별 채팅 구현
#11  - 채팅 서비스 DB 연결 및 구현
resolve - #7 , #11 

## 작업사항
- appliaction.yml MongoDB 설정
- Mongo Atlas 배포
- Spring Boot MongoDB 연결
- roomId별로 Kafka - Consumer의 consume 구현

## 변경로직(optional)
- KafkaProducer에 채팅 전송, KafkaConsumer에서 꺼낼 때 roomID에 따라 subscriber들에게 전송
