### PR TITLE
[Feat] Blob(이미지, 비디오, 파일) 채팅 전송

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
     implementation 'org.springframework.integration:spring-integration-ip'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/chat/src/main/java/pnu/cse/studyhub/chat/config/AWSConfig.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/config/AWSConfig.java
@@ -1,0 +1,29 @@
+package pnu.cse.studyhub.chat.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AWSConfig {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey,secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
+}

--- a/chat/src/main/java/pnu/cse/studyhub/chat/dto/request/ChatFileRequest.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/dto/request/ChatFileRequest.java
@@ -1,0 +1,25 @@
+package pnu.cse.studyhub.chat.dto.request;
+
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+import pnu.cse.studyhub.chat.repository.entity.Chat;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ChatFileRequest {
+    private String roomId;
+    private String senderId;
+    private String messageType;
+    private MultipartFile content;
+
+    public Chat toEntity() {
+        Chat chat = new Chat();
+        chat.setRoomId(this.roomId);
+        chat.setContent("");
+        chat.setCreatedAt(LocalDateTime.now());
+        chat.setSenderId(this.senderId);
+        chat.setMessageType(this.messageType);
+        return chat;
+    }
+}

--- a/chat/src/main/java/pnu/cse/studyhub/chat/service/KafkaProducer.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/service/KafkaProducer.java
@@ -8,22 +8,27 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import pnu.cse.studyhub.chat.repository.entity.Chat;
 
+import java.io.IOException;
+
 @Service
 @RequiredArgsConstructor // same as autowired
 @Slf4j
 public class KafkaProducer {
     private final KafkaTemplate<String, String> kafkaTemplate;
+    private final S3Uploader s3Uploader;
 
     public void send(String topic, Chat chat) {
-        log.info("topic : " + topic);
-        log.info("topic : " + chat.getContent());
+        log.info("producer_topic : " + topic);
+        log.info("producer_content : " + chat.getContent());
+        String type = chat.getMessageType();
         ObjectMapper objectMapper = new ObjectMapper();
         try {
-            String stringChat = objectMapper.writeValueAsString(chat);
-            log.info(stringChat);
-            kafkaTemplate.send(topic, stringChat);
-        } catch (JsonProcessingException e) {
+            String content = objectMapper.writeValueAsString(chat);
+            kafkaTemplate.send(topic, content);
+        } catch (JsonProcessingException e) { //json 파싱 실패
             e.printStackTrace();
+        } catch (IOException e) { // 파일 변환 실패
+            throw new RuntimeException(e);
         }
     }
 }

--- a/chat/src/main/java/pnu/cse/studyhub/chat/service/S3Uploader.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/service/S3Uploader.java
@@ -1,0 +1,94 @@
+package pnu.cse.studyhub.chat.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3Uploader {
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String base64ImageUpload(String base64,String roomId) throws IOException {
+        byte[] imageData = Base64.decodeBase64(base64);
+        String fileName = getCurrentTimeAsString() + "/" + roomId;
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(imageData));
+//        putS3(image,fileName);
+        return "";
+    }
+    public String base64FileOrVideoUpload(String base64,String roomId) throws IOException {
+        byte[] fileData = Base64.decodeBase64(base64);
+        String fileName = getCurrentTimeAsString() + "/" + roomId;
+        File file = new File(fileName);
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
+        fileOutputStream.write(fileData);
+        fileOutputStream.close();
+        String uploadImageUrl = putS3(file,fileName);
+        removeNewFile(file);
+        return uploadImageUrl;
+    }
+
+    // MultipartFile을 전달받아 File로 전환한 후 S3에 업로드
+    public String multipartFileUpload(MultipartFile multipartFile, String roomId) throws IOException {
+        String fileName = getCurrentTimeAsString() + "/" + multipartFile.getName();
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."));
+        return fileUpload(uploadFile, fileName);
+    }
+    private String fileUpload(File uploadFile, String dirName){
+        String fileName = dirName + "/" + uploadFile.getName();
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile); //로컬에 생성된 File 삭제 (MultipartFile -> File 전환하며 로컬에 파일 생성됨)
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile,String fileName){
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucket,fileName,uploadFile)
+                        .withCannedAcl(CannedAccessControlList.PublicRead)); // PublicRead 권한으로 업로드 됨
+        return amazonS3Client.getUrl(bucket,fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile){
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(file.getOriginalFilename());
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fileOutputStream = new FileOutputStream(convertFile)) {
+                fileOutputStream.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+    private String getCurrentTimeAsString(){
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String formattedDateTime = now.format(formatter);
+        return formattedDateTime;
+    }
+}

--- a/chat/src/main/resources/application.yml
+++ b/chat/src/main/resources/application.yml
@@ -38,6 +38,17 @@ springdoc:
       enabled: true
     cache:
       disabled: true
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: pnu-studyhub
+    credentials:
+      accessKey: ${STUDYHUB_S3_ACCESS_KEY}
+      secretKey: ${STUDYHUB_S3_SECRET_KEY}
+    stack:
+      auto: false
 
 eureka:
   instance:


### PR DESCRIPTION
## 개요
- Resolve #51 
- [Feat] Blob(이미지, 비디오, 파일) 채팅 전송

## 작업사항
- AWS S3 생성 및 프로젝트에 설정
- Blob 채팅 전달 시 AWS S3에 업로드
- Blob URI값 채팅방에 전달

## 변경로직(optional)
> Content-Type 헤더를 통해 /send 엔드포인트의 텍스트 채팅과 blob 채팅 구별
> blob 채팅의 경우 AWS S3 저장 -> URI 응답 -> URI를 content로 mongoDB에 저장

