### PR TITLE
Feature : 유저들의 타이머 공유 기능 추가

### DIFF
--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/config/tcp/TCPClientGateway.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/config/tcp/TCPClientGateway.java
@@ -1,5 +1,6 @@
 package pnu.cse.studyhub.signaling.config.tcp;
 
+import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.stereotype.Component;
 
@@ -7,4 +8,6 @@ import org.springframework.stereotype.Component;
 @MessagingGateway(defaultRequestChannel = "outboundChannel")
 public interface TCPClientGateway {
     String send(String message);
+
+
 }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/config/tcp/TCPMessageService.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/config/tcp/TCPMessageService.java
@@ -12,11 +12,21 @@ import java.time.LocalDateTime;
 public class TCPMessageService {
     private final TCPClientGateway tcpClientGateway;
 
-
-    public void sendMessage(String message) {
+    public String sendMessage(String message) {
         String timestamp = LocalDateTime.now().toString();
         log.info("Sending message: {}", message);
         String response = tcpClientGateway.send(message);
         log.info("Received response: {}", response);
+
+        return response;
     }
+
+//    public String requestStudyTime(String message) {
+//        String timestamp = LocalDateTime.now().toString();
+//        log.info("Sending message: {}", message);
+//
+//        String responseMessage = tcpClientGateway.sendAndReceive(message);
+//        // 응답 메시지를 파싱하여 studyTime 변수 추출
+//        return responseMessage;
+//    }
 }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/JoinRequest.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/JoinRequest.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class JoinRequest {
     private String id;
+    // TODO : token 처리 어떻게 ?
     private String token;
     private String userId;
     private long roomId;

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TCPTimerRequest.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TCPTimerRequest.java
@@ -16,8 +16,8 @@ public class TCPTimerRequest {
     private String type;
     @JsonProperty("user_id")
     private String userId;
-    @JsonProperty("time")
-    private String time;
+    @JsonProperty("study_time")
+    private String studyTime;
 
     @Override
     public String toString(){

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TCPTimerRequest.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TCPTimerRequest.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class TCPTimerRequest {
+    // TODO : TCP
     @JsonProperty("type")
     private String type;
     @JsonProperty("user_id")

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TCPUserRequest.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TCPUserRequest.java
@@ -1,0 +1,32 @@
+package pnu.cse.studyhub.signaling.dao.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TCPUserRequest {
+
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("user_id")
+    private String userId;
+
+    @Override
+    public String toString(){
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+}

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TimerRequest.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TimerRequest.java
@@ -9,8 +9,9 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class TimerRequest {
+public class TimerRequest{
     private String id;
     private String userId;
-    private boolean timer;
+    private boolean timerState;
+    // TODO : 시간도 보내줘야 하나..?
 }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TimerRequest.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TimerRequest.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -13,5 +15,5 @@ public class TimerRequest{
     private String id;
     private String userId;
     private boolean timerState;
-    // TODO : 시간도 보내줘야 하나..?
+    private LocalTime time;
 }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TimerRequest.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/request/TimerRequest.java
@@ -15,5 +15,5 @@ public class TimerRequest{
     private String id;
     private String userId;
     private boolean timerState;
-    private LocalTime time;
+    private String time;
 }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/response/ParticipantResponse.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/response/ParticipantResponse.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.sql.Timestamp;
+import java.time.LocalTime;
+
 
 @Getter
 @Setter
@@ -14,4 +17,7 @@ public class ParticipantResponse {
     private String userId;
     private boolean video;
     private boolean audio;
+    private boolean timer;
+    private LocalTime studyTime;
+    private LocalTime onTime;
 }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/response/ParticipantResponse.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/dao/response/ParticipantResponse.java
@@ -18,6 +18,6 @@ public class ParticipantResponse {
     private boolean video;
     private boolean audio;
     private boolean timer;
-    private LocalTime studyTime;
-    private LocalTime onTime;
+    private String studyTime;
+    private String onTime;
 }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/Message.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/Message.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonObject;
 
 public class Message {
 
-    // Res-1 : 새로운 유저 방접속 시 기존 유저들에 대한 정보(userId, video, audio)를 새로운 유저에게 전달
+    // Res-1 : 새로운 유저 방접속 시 기존 유저들에 대한 정보(userId, video, audio, timer, studyTime, onTime)를 새로운 유저에게 전달
     public static JsonObject existingParticipants(JsonArray participantsArray) {
         final JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("id", "existingParticipants");
@@ -14,7 +14,7 @@ public class Message {
         return jsonObject;
     }
 
-    // Res-2 : 새로운 유저 방접속 시 기존 유저들에게 새로운 유저에 대한 정보(userId, video, audio) 전달
+    // Res-2 : 새로운 유저 방접속 시 기존 유저들에게 새로운 유저에 대한 정보(userId, video, audio, timer=false, studyTime, onTime = null) 전달
     public static JsonObject newParticipantArrived(JsonElement participantInfo) {
         final JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("id", "newParticipantArrived");
@@ -65,14 +65,6 @@ public class Message {
         jsonObject.addProperty("audio", audio);
         return jsonObject;
     }
-
-    // Res-8 방 최대 접속 인원 초과 시 참가 제한 응답
-//    public static JsonObject limitJoinAnswer(String roomId) {
-//        final JsonObject jsonObject = new JsonObject();
-//        jsonObject.addProperty("id","limitJoinAnswer");
-//        jsonObject.addProperty("roomId", roomId);
-//        return jsonObject;
-//    }
 
 
 }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/Message.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/Message.java
@@ -4,6 +4,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import java.time.LocalTime;
+
 public class Message {
 
     // Res-1 : 새로운 유저 방접속 시 기존 유저들에 대한 정보(userId, video, audio, timer, studyTime, onTime)를 새로운 유저에게 전달
@@ -63,6 +65,21 @@ public class Message {
         jsonObject.addProperty("id","audioStateAnswer");
         jsonObject.addProperty("userId", userId);
         jsonObject.addProperty("audio", audio);
+        return jsonObject;
+    }
+
+    // Res-8 : 타이머 상태 변경에 대한 응답
+    public static JsonObject timerStateAnswer(String userId, boolean timer, LocalTime time) {
+        final JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("id","timerStateAnswer");
+        jsonObject.addProperty("userId", userId);
+        jsonObject.addProperty("timerState", timer);
+        if(timer){ // on 이면 현재시간도 추가
+            jsonObject.addProperty("time", time.toString());
+        }else{
+            jsonObject.addProperty("studyTime", time.toString());
+        }
+
         return jsonObject;
     }
 

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/Message.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/Message.java
@@ -69,15 +69,15 @@ public class Message {
     }
 
     // Res-8 : 타이머 상태 변경에 대한 응답
-    public static JsonObject timerStateAnswer(String userId, boolean timer, LocalTime time) {
+    public static JsonObject timerStateAnswer(String userId, boolean timer, String time) {
         final JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("id","timerStateAnswer");
         jsonObject.addProperty("userId", userId);
         jsonObject.addProperty("timerState", timer);
         if(timer){ // on 이면 현재시간도 추가
-            jsonObject.addProperty("time", time.toString());
+            jsonObject.addProperty("onTime", time);
         }else{
-            jsonObject.addProperty("studyTime", time.toString());
+            jsonObject.addProperty("studyTime", time);
         }
 
         return jsonObject;

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/Room.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/Room.java
@@ -99,13 +99,16 @@ public class Room implements Closeable {
 
     // 특정 유저가 방에서 나갔을 때, 그 유저가 떠난 사실을 해당 방에 참여하고 있는 모든 유저들에게 알림
 
-    private void removeParticipant(String userId) throws IOException {
+    public void removeParticipant(String userId) throws IOException {
+        // 해당 방의 참가자들(participants) 중에 방을 나간 userId를 삭제하고
         participants.remove(userId);
 
         final List<String> unnotifiedParticipants = new ArrayList<>();
         final JsonObject participantLeftJson = participantLeft(userId);
+        // 남아 있는 참가자들한테 해당 userId가 나간사실을 알림
         for (final UserSession participant : participants.values()) {
             try {
+                // 남아 있는 참가자의 incomingMedia에서 userId를 없애줘야함
                 participant.cancelVideoFrom(userId);
                 participant.sendMessage(participantLeftJson);
             } catch (final IOException e) {

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserRegistry.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserRegistry.java
@@ -37,7 +37,7 @@ public class UserRegistry {
     public UserSession removeBySession(WebSocketSession session) {
         final UserSession user = getBySession(session);
         // 웹소켓 연결만 하고 방에 입장하지 않고 종료하지 않는 경우 발생하는 예외 처리
-        if (!Objects.isNull(user)) {
+        if (!Objects.isNull(user)) { // 존재하면
             usersByUserId.remove(user.getUserId());
             usersBySessionId.remove(session.getId());
             return user;

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserSession.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserSession.java
@@ -210,8 +210,19 @@ public class UserSession implements Closeable {
     }
 
     public void cancelVideoFrom(final String senderName) {
+        System.out.println("=============>>>>>>");
+        System.out.println(this.userId + "'s incomingMedia : "+incomingMedia.toString());
+        if(incomingMedia.containsKey(senderName)){
+            System.out.println("노에러!!");
+        }else{
+            // 안에 없으면
+            System.out.println("에러!!");
+        }
         final WebRtcEndpoint incoming = incomingMedia.remove(senderName);
+        System.out.println(this.userId + "'s incomingMedia : "+incomingMedia.toString());
+        System.out.println("<<<<<<=============");
 
+        // TODO : 그냥 브라우저 종료는 에러 x , leave room 했을때
         incoming.release(new Continuation<Void>() {
             @Override
             public void onSuccess(Void result) throws Exception { }

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserSession.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserSession.java
@@ -12,6 +12,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -63,7 +64,6 @@ public class UserSession implements Closeable {
             // 이벤트가 발생했을 때 다른 유저들에게 새로운 iceCandidate 후보를 알림
             @Override
             public void onEvent(IceCandidateFoundEvent event) {
-                log.info("ICE Candidate Message 전송 ----->");
                 JsonObject response = iceCandidate(userId, JsonUtils.toJsonObject(event.getCandidate()));
                 try {
                     // 여러 개의 스레드에서 동시에 session 객체에 접근하는 것을 막음
@@ -186,7 +186,6 @@ public class UserSession implements Closeable {
                 // 새로운 WebRtcEndpoint 객체를 만들고 ICE Candidate를 발견할 때마다 처리
                 @Override
                 public void onEvent(IceCandidateFoundEvent event) {
-                    log.info("ICE Candidate Message 전송 ----->");
                     JsonObject response = iceCandidate(sender.getUserId(), JsonUtils.toJsonObject(event.getCandidate()));
                     try {
                         synchronized (session) {
@@ -267,6 +266,31 @@ public class UserSession implements Closeable {
                 webRtc.addIceCandidate(candidate);
             }
         }
+    }
+
+    // userSession 객체가 user.getStudyTime().toString() 이렇게해서 자기의 studyTime을 String으로 바꿈
+    // 메소드 하나 만들어주자 (초까지 출력)
+    // 00:00:00 이런식으로 String 출력하기 (StringBuffer)
+    public String studyTimeToString(){
+
+        DateTimeFormatter formatter =  DateTimeFormatter.ofPattern("HH:mm:ss");
+        String formattedTime = this.studyTime.format(formatter);
+
+        return formattedTime;
+    }
+
+    public String onTimeToString(){
+
+        if(this.onTime != null){
+            DateTimeFormatter formatter =  DateTimeFormatter.ofPattern("HH:mm:ss");
+            String formattedTime = this.onTime.format(formatter);
+
+            return formattedTime;
+        }
+        else{ // null이면
+            return "";
+        }
+
     }
 
     @Override

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserSession.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserSession.java
@@ -119,6 +119,17 @@ public class UserSession implements Closeable {
     public LocalTime getOnTime() {return onTime;}
 
     public void setOnTime(LocalTime onTime) {this.onTime = onTime;}
+    public void countStudyTime(LocalTime offTime, LocalTime onTime){
+        onTime.minusHours(offTime.getHour());
+        onTime.minusMinutes(offTime.getMinute());
+        onTime.minusSeconds(offTime.getSecond());
+
+        this.studyTime.minusHours(onTime.getHour());
+        this.studyTime.minusMinutes(onTime.getMinute());
+        this.studyTime.minusSeconds(onTime.getSecond());
+    }
+
+
     /*
          - SDP : 미디어 스트림 전송에 필요한 많은 정보 포함
                 WebRTC 통신을 위해서는 먼저 SDP를 교환해야 함 (브라우저 끼리는 Offer/Answer 모델)

--- a/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserSession.java
+++ b/signaling/src/main/java/pnu/cse/studyhub/signaling/util/UserSession.java
@@ -10,6 +10,8 @@ import org.kurento.jsonrpc.JsonUtils;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.LocalTime;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -28,13 +30,20 @@ public class UserSession implements Closeable {
     private boolean audio;
     private boolean timer;
 
+    // TODO : 나중에 수정 될수도
+
+    private LocalTime studyTime;
+    private LocalTime onTime;
+
+    /////
+
     // 현재 나의 webRtcEndPoint 객체니깐 밖으로 내보낸다는 의미
     private final WebRtcEndpoint outgoingMedia;
 
     // 나와 연결되어야 할 다른 사람의 webRtcEndPoint 객체들이라 map 형태로 저장
     private final ConcurrentMap<String, WebRtcEndpoint> incomingMedia = new ConcurrentHashMap<>();
 
-    public UserSession(String userId, Long roomId, WebSocketSession session, MediaPipeline pipeline, boolean video, boolean audio) {
+    public UserSession(String userId, Long roomId, WebSocketSession session, MediaPipeline pipeline, boolean video, boolean audio, LocalTime studyTime) {
 
         this.userId = userId;
         this.session = session;
@@ -42,7 +51,12 @@ public class UserSession implements Closeable {
         this.roomId = roomId;
         this.video = video;
         this.audio = audio;
+
+        // Timer 관련
         this.timer = false;
+        this.studyTime = studyTime;
+        this.onTime = null;
+
         this.outgoingMedia = new WebRtcEndpoint.Builder(pipeline).build();
         this.outgoingMedia.addIceCandidateFoundListener(new EventListener<IceCandidateFoundEvent>() {
             // iceCandidateFounder 이벤트 리스너 등록
@@ -97,6 +111,14 @@ public class UserSession implements Closeable {
     }
     public boolean getTimer() {return this.timer;}
     public void setTimer(boolean timer) { this.timer = timer; }
+
+    public LocalTime getStudyTime() {return studyTime;}
+
+    public void setStudyTime(LocalTime studyTime) {this.studyTime = studyTime;}
+
+    public LocalTime getOnTime() {return onTime;}
+
+    public void setOnTime(LocalTime onTime) {this.onTime = onTime;}
     /*
          - SDP : 미디어 스트림 전송에 필요한 많은 정보 포함
                 WebRTC 통신을 위해서는 먼저 SDP를 교환해야 함 (브라우저 끼리는 Offer/Answer 모델)


### PR DESCRIPTION
## 개요
- #67 

## 작업사항
- 유저객체 생성되면 상태관리서버로 studyTime 요청한 후 받아온 걸로 객체 생성하기
- 새로운 유저가 방에 입장했을 때, 기존 유저들과 새 유저간의 타이머상태, 공부시간 공유
- 클라이언트쪽에서 웹소켓으로 보낸 TimerRequest받아서 해당 방에 있는 모든 유저에게 timerStateAnswer을 보내줌
- 유저가 방을 나가거나 웹소켓이 끊어질 때마다, userId랑 studyTime 데이터를 상태관리 서버(TCP 서버)에 TCP로 보내줌

## 변경로직(optional)
- 기존 redis로 유저의 studyTime을 시그널링 서버에서 관리 할려고 했으나 상태관리서버에서 studyTime을 저장해서 요청해서 받아오는 식으로 구현함
