### PR TITLE
Fix : SockJs 연결 안되는 문제 해결

### DIFF
--- a/chat/src/main/java/pnu/cse/studyhub/chat/config/kafka/MessageChannelInterceptor.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/config/kafka/MessageChannelInterceptor.java
@@ -52,7 +52,7 @@ public class MessageChannelInterceptor implements ChannelInterceptor {
 //                        .userId(userId)
                         .userId("test1")
                         .server("chat")
-                        .roomId(accessor.getDestination().substring(7)) // 슬래쉬 ( '/' ) 삭제
+                        .roomId(accessor.getDestination().substring(7)) // 슬래쉬 ( '/topic/' ) 삭제
                         .session(sessionId)
                         .build();
                 log.warn("test + " + subscribeRequest.toString());
@@ -63,7 +63,7 @@ public class MessageChannelInterceptor implements ChannelInterceptor {
 //                        .userId(userId)
                         .server("chat")
                         .userId("test1")
-                        .roomId(accessor.getDestination().substring(7)) // 슬래쉬 ( '/' ) 삭제
+                        .roomId(accessor.getDestination().substring(7)) // 슬래쉬 ( '/topic/' ) 삭제
                         .session(sessionId)
                         .build();
                 log.info("UserId : " + userId);

--- a/chat/src/main/java/pnu/cse/studyhub/chat/config/kafka/WebSocketMessageBrokerConfig.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/config/kafka/WebSocketMessageBrokerConfig.java
@@ -15,20 +15,17 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
     private final MessageChannelInterceptor messageChannelInterceptor;
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // withSockJS - 소켓을 지원하지 않는 브라우저라면, sockJS사용하도록 설정
-        registry
-                .addEndpoint("/connect")
-                        .setAllowedOrigins("*");
-        registry.addEndpoint("/connect").setAllowedOrigins("*").withSockJS();
+        // withSockJS - 소켓을 지원하지 않는 브라우저라면, sockJS사용하도록 설정, test 도메인 : https://jxy.me
+        registry.addEndpoint("/chat/connect").setAllowedOrigins("https://jxy.me").withSockJS();
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 메세지를 보낼 때, 관련 경로를 설정
         // 클라이언트가 메세지를 보낼 때, 경로 앞에 "/topic"이 붙어있으면 Broker로 보냄
-        registry.setApplicationDestinationPrefixes("/kafka");
+        registry.setApplicationDestinationPrefixes("/pub");
         // 메세지를 받을 때, 관련 경로를 설정
-        //
+//        registry.enableSimpleBroker("/sub");
         registry.enableSimpleBroker("/topic");
     }
 


### PR DESCRIPTION
- setAllowedOrigins를 특정 테스트 도메인으로 지정
- 테스트 결과 정상 동작 확인

## 개요
- #69 
- Resolve #69 [BUG] 채팅 서버 - SockJs의 경우 연결 안되는 문제

## 작업사항
- setAllowedOrigins(*) 관련 에러 로그 확인

## 변경로직(optional)
- https://jxy.me 라는 stomp 테스트 페이지만 허용
