### PR TITLE
Feat : 스터디방 In/Out 시 유저 공부 시간 관리

### DIFF
--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/TCPMessageRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/TCPMessageRequest.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
         visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = TCPChatRequest.class, name = "chat"),
-        @JsonSubTypes.Type(value = TCPSignalingRequest.class, name = "room")
+        @JsonSubTypes.Type(value = TCPSignalingRequest.class, name = "signaling")
 })
 public abstract class TCPMessageRequest{
     private String server;

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/TCPSignalingRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/TCPSignalingRequest.java
@@ -17,10 +17,10 @@ import java.time.LocalDateTime;
 public class TCPSignalingRequest extends TCPMessageRequest{
     @JsonProperty("user_id")
     private String userId;
-    @JsonProperty("action")
-    private String action;
-    @JsonProperty("study_start_time")
-    private LocalDateTime studyStartTime;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("study_time")
+    private String studyTime;
     @Override
     public String toString(){
         ObjectMapper mapper = new ObjectMapper();

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/response/TCPSignalingResponse.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/response/TCPSignalingResponse.java
@@ -1,0 +1,16 @@
+package pnu.cse.studyhub.state.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TCPSignalingResponse {
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("study_time")
+    private String studyTime;
+}

--- a/state/src/main/java/pnu/cse/studyhub/state/repository/entity/RealTimeData.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/repository/entity/RealTimeData.java
@@ -16,8 +16,9 @@ public class RealTimeData {
     private String userId;
     private Long roomId;
     private String sessionId;
-    // 현재시각 - 타이머 시작 시간
-    private LocalDateTime studyStartTime;
-    // 이전까지 기록된 총 공부 시간
-    private Duration recordTime;
+    private String studyTime;
+//    // 현재시각 - 타이머 시작 시간
+//    private LocalDateTime studyStartTime;
+//    // 이전까지 기록된 총 공부 시간
+//    private Duration recordTime;
 }

--- a/state/src/main/java/pnu/cse/studyhub/state/service/MessageService.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/service/MessageService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import pnu.cse.studyhub.state.dto.request.TCPChatRequest;
 import pnu.cse.studyhub.state.dto.request.TCPMessageRequest;
 import pnu.cse.studyhub.state.dto.request.TCPSignalingRequest;
+import pnu.cse.studyhub.state.dto.response.TCPSignalingResponse;
 import pnu.cse.studyhub.state.repository.entity.RealTimeData;
 
 import java.time.Duration;
@@ -26,7 +27,8 @@ public class MessageService {
         ObjectMapper mapper = new ObjectMapper();
         try{
             TCPMessageRequest response = mapper.readValue(message, TCPMessageRequest.class);
-            String responseMessage = String.format("Message \"%s\" is processed", response.toString());
+//            String responseMessage = String.format("Message \"%s\" is processed", response.toString());
+            String responseMessage = "";
             switch (response.getServer()) {
                 case "chat":
                     TCPChatRequest chatRequest = (TCPChatRequest) response;
@@ -38,45 +40,66 @@ public class MessageService {
                             realTimeData.setUserId(chatRequest.getUserId());
                             realTimeData.setRoomId(chatRequest.getRoomId());
                             realTimeData.setSessionId(chatRequest.getSession());
-                            RealTimeData realTimeData1 =  redisService.setData(realTimeData);
+                            RealTimeData chatSubscribeRealTimeData =  redisService.setData(realTimeData);
+                            responseMessage = mapper.writeValueAsString(chatSubscribeRealTimeData);
                         } else {
                             realTimeData.setRoomId(chatRequest.getRoomId());
                             realTimeData.setSessionId(chatRequest.getSession());
-                            RealTimeData realTimeData2 = redisService.setData(realTimeData);
+                            RealTimeData chatSubscribeRealTimeData = redisService.setData(realTimeData);
+                            responseMessage = mapper.writeValueAsString(chatSubscribeRealTimeData);
                         }
-
                     } else if (chatRequest.getType().matches("DISCONNECT")) {
                         RealTimeData realTimeData = redisService.getData(chatRequest.getUserId());
                         if (realTimeData != null) {
                             realTimeData.setRoomId(chatRequest.getRoomId());
                             realTimeData.setSessionId(null);
-                            redisService.setData(realTimeData);
+                            RealTimeData chatDisconnectRealTimeData = redisService.setData(realTimeData);
+                            responseMessage = mapper.writeValueAsString(chatDisconnectRealTimeData);
+                        } else {
+                            //예외처리
                         }
+
                     } else {
                         // 에러처리
                     }
+
+
                     break;
                 case "signaling":
                     TCPSignalingRequest signalingRequest = (TCPSignalingRequest) response;
                     log.warn(signalingRequest.toString());
-                    if (signalingRequest.getAction().matches("TIMER_ON")) {
+                    // Signaling 서버에 StudyTime 전달.
+                    if (signalingRequest.getType().matches("STUDY_TIME_FROM_TCP")) {
                         try {
                             RealTimeData realTimeData =  redisService.getData(signalingRequest.getUserId());
-                            LocalDateTime currentTime = LocalDateTime.now();
-                            realTimeData.setStudyStartTime(currentTime);
-                            RealTimeData savedData = redisService.setData(realTimeData);
+                            if (realTimeData != null) {
+                                TCPSignalingResponse signalingGetResponse = TCPSignalingResponse.builder()
+                                        .userId(realTimeData.getUserId())
+                                        .studyTime(realTimeData.getStudyTime())
+                                        .build();
+                                responseMessage = mapper.writeValueAsString(signalingGetResponse);
+                            } else {
+                                //예외처리
+                            }
+
                         }catch (Exception e) {
                             throw new RuntimeException(e);
                         }
-                    } else if (signalingRequest.getAction().matches("TIMER_OFF")) {
+                    // Signaling 서버로부터 StudyTime 저장.
+                    } else if (signalingRequest.getType().matches("STUDY_TIME_TO_TCP")) {
                         try {
                             RealTimeData realTimeData =  redisService.getData(signalingRequest.getUserId());
-                            LocalDateTime currentTime = LocalDateTime.now();
-                            LocalDateTime studyStartTime = realTimeData.getStudyStartTime();
-                            Duration totalStudyTime = Duration.between(studyStartTime, currentTime);
-                            realTimeData.setStudyStartTime(null);
-                            realTimeData.setRecordTime(totalStudyTime);
-                            RealTimeData savedData = redisService.setData(realTimeData);
+                            if (realTimeData != null) {
+                                realTimeData.setStudyTime(signalingRequest.getStudyTime());
+                                RealTimeData signalingSetRealTimeData = redisService.setData(realTimeData);
+                                TCPSignalingResponse signalingSetResponse = TCPSignalingResponse.builder()
+                                        .userId(signalingSetRealTimeData.getUserId())
+                                        .studyTime(signalingSetRealTimeData.getStudyTime())
+                                        .build();
+                                responseMessage = mapper.writeValueAsString(signalingSetResponse);
+                            } else {
+                                //예외처리
+                            }
                         }catch (Exception e) {
                             throw new RuntimeException(e);
                         }
@@ -85,6 +108,7 @@ public class MessageService {
                     }
                     break;
             }
+            log.warn("responseMessage : " + responseMessage);
             return responseMessage;
         } catch (JsonMappingException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION


## 개요
- #63
- Resolve [Feat] 상태관리서버 - 스터디방 In/Out 시 유저 공부 시간 관리

## 작업사항
- 시그널링 서버에서 채팅방 입장 시, 유저의 공부 시간 받아오기 (type = STUDY_TIME_FROM_TCP)
- 시그널링 서버에서 채팅방 나갈 시, 유저의 공부 시간 저장하기 (type = STUDY_TIME_TO_TCP)
- signaling 서버 응답 DTO, TCPSignalingResponse 개발

## 변경로직(optional)
- TCP signaling 에서 요청 사항을 반영하는 프로퍼티를 action -> type 으로 변경
