### PR TITLE
[Feat] 채팅 서버 - jwt 토큰 활용

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
     implementation 'org.springframework.integration:spring-integration-ip'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/chat/src/main/java/pnu/cse/studyhub/chat/config/kafka/MessageChannelInterceptor.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/config/kafka/MessageChannelInterceptor.java
@@ -2,7 +2,6 @@ package pnu.cse.studyhub.chat.config.kafka;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -10,19 +9,25 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 import pnu.cse.studyhub.chat.config.tcp.TCPMessageService;
-import pnu.cse.studyhub.chat.dto.request.TCPMessageRequest;
 import pnu.cse.studyhub.chat.dto.request.TCPSocketSessionRequest;
+import pnu.cse.studyhub.chat.service.JwtTokenProvider;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class MessageChannelInterceptor implements ChannelInterceptor {
     private final TCPMessageService tcpMessageService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 메세지가 전송되기 전에 Intercept
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+//        jwt 토큰 검증, gateway에서 검증 되었기 때문에 userId를 쓰기만 하면됨.
+//        String authorizationHeader = String.valueOf(accessor.getFirstNativeHeader("Authorization"));
+//        String accessToken = authorizationHeader.replace("Bearer ", "");
+//        String userId = jwtTokenProvider.getUserInfo(accessToken);
+
         if (StompCommand.CONNECT.equals(accessor.getCommand())){
             //jwt 토큰 필터링
             //토큰 데이터를 통해서 header에 userId를 넣어줌
@@ -43,14 +48,18 @@ public class MessageChannelInterceptor implements ChannelInterceptor {
     public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         String sessionId = accessor.getSessionId();
-        String userId = accessor.getFirstNativeHeader("userId");
+//        jwt 토큰 검증, gateway에서 검증 되었기 때문에 userId를 쓰기만 하면됨.
+        String authorizationHeader = String.valueOf(accessor.getFirstNativeHeader("Authorization"));
+        String accessToken = authorizationHeader.replace("Bearer ", "");
+        String userId = jwtTokenProvider.getUserInfo(accessToken);
+        log.error(authorizationHeader + " : " + accessToken + " : " + userId);
+
         switch (accessor.getCommand()){
             case SUBSCRIBE: // room ID에 들어갈 때(소켓 연결이 아니라 채팅방에 들어갈 때 )
                 TCPSocketSessionRequest subscribeRequest = TCPSocketSessionRequest.builder()
                         .type("SUBSCRIBE")
-                        // "Timer ON TIMER OFF 프론트에서 보내는ㅅ거, USEROUT USErIN 프론트에서 받는거
-//                        .userId(userId)
-                        .userId("test1")
+                        // "Timer ON TIMER OFF 프론트에서 보내는ㅅ거, USER_OUT, USER_IN 프론트에서 받는거
+                        .userId(userId)
                         .server("chat")
                         .roomId(accessor.getDestination().substring(7)) // 슬래쉬 ( '/topic/' ) 삭제
                         .session(sessionId)
@@ -60,9 +69,8 @@ public class MessageChannelInterceptor implements ChannelInterceptor {
             case DISCONNECT: // 채팅방 나갈 때
                 TCPSocketSessionRequest disconnectRequest = TCPSocketSessionRequest.builder()
                         .type("DISCONNECT")
-//                        .userId(userId)
+                        .userId(userId)
                         .server("chat")
-                        .userId("test1")
                         .roomId(accessor.getDestination().substring(7)) // 슬래쉬 ( '/topic/' ) 삭제
                         .session(sessionId)
                         .build();

--- a/chat/src/main/java/pnu/cse/studyhub/chat/controller/ChatController.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/controller/ChatController.java
@@ -55,8 +55,10 @@ public class ChatController {
             @Parameter(name = "content", description = "채팅 내용", example = "chat test"),
     })
     @PostMapping(value = "/send", consumes = "application/json")
-    public ResponseEntity<SuccessResponse> sendMessage(@RequestBody ChatRequest chat) {
-        Chat savedChat = chatService.saveChat(chat);
+    //public ResponseEntity<SuccessResponse> sendMessage(@CookieValue("accessToken") String accessToken, @RequestBody ChatRequest chat) {
+    public ResponseEntity<SuccessResponse> sendMessage(@RequestHeader("Authorization") String authorization, @RequestBody ChatRequest chat) {
+        String accessToken = authorization.replace("Bearer ","");
+        Chat savedChat = chatService.saveChat(accessToken, chat );
         log.info("Produce message : " + savedChat.toString());
         try {
             kafkaProducer.send(TOPIC,savedChat);

--- a/chat/src/main/java/pnu/cse/studyhub/chat/service/ChatService.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/service/ChatService.java
@@ -21,10 +21,15 @@ public class ChatService {
 
     private final ChatRepository chatRepository;
     private final S3Uploader s3Uploader;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public Chat saveChat(ChatRequest chatRequest){
+    public Chat saveChat(String jwtToken, ChatRequest chatRequest){
         Chat chatEntity = chatRequest.toEntity();
+        log.error(chatEntity.toString());
+        String senderId = jwtTokenProvider.getUserInfo(jwtToken);
+        chatEntity.setSenderId(senderId);
         Chat savedChat = chatRepository.save(chatEntity);
+        log.error(savedChat.toString());
         return savedChat;
     }
     public Chat saveFileChat(ChatFileRequest chatFileRequest){

--- a/chat/src/main/java/pnu/cse/studyhub/chat/service/JwtTokenProvider.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/service/JwtTokenProvider.java
@@ -1,0 +1,20 @@
+package pnu.cse.studyhub.chat.service;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${token.secret}")
+    private String SECRET_KEY;
+
+    public String getUserInfo(String token) {
+        return Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody().getSubject();
+    }
+}

--- a/chat/src/main/resources/application.yml
+++ b/chat/src/main/resources/application.yml
@@ -54,6 +54,9 @@ cloud:
     stack:
       auto: false
 
+token:
+  secret: user_token
+
 tcp:
   server:
     host: localhost


### PR DESCRIPTION
## 개요
- #71 
- Resolve #71 [Feat] 채팅 서버 - jwt 토큰 활용

## 작업사항
- AccessToken의 userId로 senderId 설정(보낸 사람)
- AccessToken의 userId로 소켓 연결 Id 설정(접속 혹은 접속 해제한 사람)

## 변경로직(optional)
- JwtTokenProvider 컴포넌트 생성
- Chat Controller, Service에서 jwt 토큰 얻고 파싱
- application.yml에 token secret key 설정(환경 변수로 변경 예정)
- MessageChannelInterceptor에 접속 상태 저장 시 jwt 토큰의 userId로 저장
