### PR TITLE
Fix : 접속 상태 관리 로직 변경

### DIFF
--- a/state/src/main/java/pnu/cse/studyhub/state/config/RedisConfig.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/config/RedisConfig.java
@@ -7,7 +7,9 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import pnu.cse.studyhub.state.repository.entity.RealTimeData;
 
 @Configuration
 @EnableRedisRepositories
@@ -25,13 +27,22 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
+    public RedisTemplate<String, RealTimeData> realTimeDataRedisTemplate() {
+        RedisTemplate<String, RealTimeData> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(RealTimeData.class));
+        redisTemplate.setDefaultSerializer(new Jackson2JsonRedisSerializer<>(RealTimeData.class));
+        return redisTemplate;
+    }
+    @Bean
+    public RedisTemplate<String, String> sessionRedisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
 
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
-
         return redisTemplate;
     }
 }

--- a/state/src/main/java/pnu/cse/studyhub/state/repository/RedisRepository.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/repository/RedisRepository.java
@@ -10,5 +10,6 @@ import java.util.List;
 @Repository
 @EnableRedisRepositories
 public interface RedisRepository extends CrudRepository<RealTimeData, String> {
+    RealTimeData findBySessionId(String sessionId);
 
 }

--- a/state/src/main/resources/application.yml
+++ b/state/src/main/resources/application.yml
@@ -21,4 +21,4 @@ tcp:
       poolSize : 30
 logging:
   level:
-    pnu.cse.studyhub: INFO
+    pnu.cse.studyhub: DEBUG


### PR DESCRIPTION
## 개요
- Resolve #85 

## 작업사항
- SUBSCRIBE / DISCONNECT|UNSUBSCRIBE 시 소켓 세션 저장 / 삭제 구현
- sessionRedisTemplate, realTimeDataRedisTemplate 두개의 빈 생성 및 활용


## 변경로직(optional)
- 데이터 저장 시 RealTimeData(JSON), sessionData(STRING)로 분리해서 저장 -> sessionId 으로 데이터 삭제하기 위함.
