### PR TITLE
Feat : 경고, 강제퇴장, 경고 누적 퇴장, 방장 위임 기능 구현 

### DIFF
--- a/state/src/main/java/pnu/cse/studyhub/state/config/TCPRoomClientConfig.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/config/TCPRoomClientConfig.java
@@ -15,7 +15,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 
 @Configuration
-public class TCPClientConfig implements ApplicationEventPublisherAware {
+public class TCPRoomClientConfig implements ApplicationEventPublisherAware {
     @Value("${tcp.room.host}")
     private String host;
 
@@ -33,7 +33,7 @@ public class TCPClientConfig implements ApplicationEventPublisherAware {
     }
 
     @Bean
-    public AbstractClientConnectionFactory clientConnectionFactory() {
+    public AbstractClientConnectionFactory roomClientConnectionFactory() {
         TcpNioClientConnectionFactory tcpNioClientConnectionFactory = new TcpNioClientConnectionFactory(host, port);
         tcpNioClientConnectionFactory.setUsingDirectBuffers(true);
         tcpNioClientConnectionFactory.setApplicationEventPublisher(applicationEventPublisher);
@@ -42,15 +42,15 @@ public class TCPClientConfig implements ApplicationEventPublisherAware {
 
 
     @Bean
-    public MessageChannel outboundChannel() {
+    public MessageChannel roomOutboundChannel() {
         return new DirectChannel();
     }
 
     @Bean
-    @ServiceActivator(inputChannel = "outboundChannel")
-    public MessageHandler outboundGateway(AbstractClientConnectionFactory clientConnectionFactory) {
+    @ServiceActivator(inputChannel = "roomOutboundChannel")
+    public MessageHandler roomOutboundGateway(AbstractClientConnectionFactory roomClientConnectionFactory) {
         TcpOutboundGateway tcpOutboundGateway = new TcpOutboundGateway();
-        tcpOutboundGateway.setConnectionFactory(clientConnectionFactory);
+        tcpOutboundGateway.setConnectionFactory(roomClientConnectionFactory);
         return tcpOutboundGateway;
     }
 }

--- a/state/src/main/java/pnu/cse/studyhub/state/config/TCPRoomClientGateway.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/config/TCPRoomClientGateway.java
@@ -4,7 +4,7 @@ import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.stereotype.Component;
 
 @Component
-@MessagingGateway(defaultRequestChannel = "outboundChannel")
-public interface TCPClientGateway {
+@MessagingGateway(defaultRequestChannel = "roomOutboundChannel")
+public interface TCPRoomClientGateway {
     String send(String message);
 }

--- a/state/src/main/java/pnu/cse/studyhub/state/config/TCPSignalingClientConfig.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/config/TCPSignalingClientConfig.java
@@ -1,0 +1,56 @@
+package pnu.cse.studyhub.state.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.ip.tcp.TcpOutboundGateway;
+import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.CachingClientConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.TcpNioClientConnectionFactory;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+
+@Configuration
+public class TCPSignalingClientConfig implements ApplicationEventPublisherAware {
+    @Value("${tcp.signaling.host}")
+    private String host;
+
+    @Value("${tcp.signaling.port}")
+    private int port;
+
+    @Value("${tcp.signaling.connection.poolSize}")
+    private int connectionPoolSize;
+
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    @Bean
+    public AbstractClientConnectionFactory signalingClientConnectionFactory() {
+        TcpNioClientConnectionFactory tcpNioClientConnectionFactory = new TcpNioClientConnectionFactory(host, port);
+        tcpNioClientConnectionFactory.setUsingDirectBuffers(true);
+        tcpNioClientConnectionFactory.setApplicationEventPublisher(applicationEventPublisher);
+        return new CachingClientConnectionFactory(tcpNioClientConnectionFactory, connectionPoolSize);
+    }
+
+
+    @Bean
+    public MessageChannel signalingOutboundChannel() {
+        return new DirectChannel();
+    }
+
+    @Bean
+    @ServiceActivator(inputChannel = "signalingOutboundChannel")
+    public MessageHandler signalingOutboundGateway(AbstractClientConnectionFactory signalingClientConnectionFactory) {
+        TcpOutboundGateway tcpOutboundGateway = new TcpOutboundGateway();
+        tcpOutboundGateway.setConnectionFactory(signalingClientConnectionFactory);
+        return tcpOutboundGateway;
+    }
+}

--- a/state/src/main/java/pnu/cse/studyhub/state/config/TCPSignalingClientGateway.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/config/TCPSignalingClientGateway.java
@@ -1,0 +1,10 @@
+package pnu.cse.studyhub.state.config;
+
+import org.springframework.integration.annotation.MessagingGateway;
+import org.springframework.stereotype.Component;
+
+@Component
+@MessagingGateway(defaultRequestChannel = "signalingOutboundChannel")
+public interface TCPSignalingClientGateway {
+    String send(String message);
+}

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPAuthReceiveRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPAuthReceiveRequest.java
@@ -1,4 +1,4 @@
-package pnu.cse.studyhub.state.dto.request;
+package pnu.cse.studyhub.state.dto.request.receive;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -11,14 +11,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@JsonTypeName("chat")
-public class TCPChatRequest extends TCPMessageRequest{
+@JsonTypeName("auth")
+public class TCPAuthReceiveRequest extends TCPMessageReceiveRequest {
     @JsonProperty("user_id")
     private String userId;
-    @JsonProperty("room_id")
-    private Long roomId;
-    @JsonProperty("session")
-    private String session;
+//    @JsonProperty("room_id")
+//    private Long roomId;
+//    @JsonProperty("session")
+//    private String session;
     @JsonProperty("type")
     private String type;
     @Override

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPChatReceiveRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPChatReceiveRequest.java
@@ -1,4 +1,4 @@
-package pnu.cse.studyhub.state.dto.request;
+package pnu.cse.studyhub.state.dto.request.receive;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -8,19 +8,19 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@JsonTypeName("signaling")
-public class TCPSignalingRequest extends TCPMessageRequest{
+@JsonTypeName("chat")
+public class TCPChatReceiveRequest extends TCPMessageReceiveRequest {
     @JsonProperty("user_id")
     private String userId;
+    @JsonProperty("room_id")
+    private Long roomId;
+    @JsonProperty("session")
+    private String session;
     @JsonProperty("type")
     private String type;
-    @JsonProperty("study_time")
-    private String studyTime;
     @Override
     public String toString(){
         ObjectMapper mapper = new ObjectMapper();
@@ -31,4 +31,3 @@ public class TCPSignalingRequest extends TCPMessageRequest{
         }
     }
 }
-

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPMessageReceiveRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPMessageReceiveRequest.java
@@ -1,4 +1,4 @@
-package pnu.cse.studyhub.state.dto.request;
+package pnu.cse.studyhub.state.dto.request.receive;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -15,11 +15,12 @@ import lombok.NoArgsConstructor;
         property = "server",
         visible = true)
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = TCPChatRequest.class, name = "chat"),
-        @JsonSubTypes.Type(value = TCPSignalingRequest.class, name = "signaling"),
-        @JsonSubTypes.Type(value = TCPAuthRequest.class, name = "auth")
+        @JsonSubTypes.Type(value = TCPChatReceiveRequest.class, name = "chat"),
+        @JsonSubTypes.Type(value = TCPSignalingReceiveRequest.class, name = "signaling"),
+        @JsonSubTypes.Type(value = TCPAuthReceiveRequest.class, name = "auth"),
+        @JsonSubTypes.Type(value = TCPRoomReceiveRequest.class, name = "room")
 })
-public abstract class TCPMessageRequest{
+public abstract class TCPMessageReceiveRequest {
     private String server;
 
 }

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPRoomReceiveRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPRoomReceiveRequest.java
@@ -1,0 +1,37 @@
+package pnu.cse.studyhub.state.dto.request.receive;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import pnu.cse.studyhub.state.dto.request.send.TCPSignalingSendRequest;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@JsonTypeName("room")
+public class TCPRoomReceiveRequest extends TCPMessageReceiveRequest {
+    @JsonProperty("server")
+    private String server;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("room_id")
+    private Long roomId;
+    @JsonProperty("alert_count")
+    private Long alertCount;
+
+    public TCPSignalingSendRequest toTCPSignalingSendRequest() {
+        return TCPSignalingSendRequest.builder()
+                .server("state")
+                .type(this.type)
+                .userId(this.userId)
+                .roomId(this.roomId)
+                .alertCount(this.alertCount)
+                .build();
+    }
+}

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPSignalingReceiveRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPSignalingReceiveRequest.java
@@ -1,4 +1,4 @@
-package pnu.cse.studyhub.state.dto.request;
+package pnu.cse.studyhub.state.dto.request.receive;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -8,21 +8,17 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@JsonTypeName("auth")
-public class TCPAuthRequest extends TCPMessageRequest{
+@JsonTypeName("signaling")
+public class TCPSignalingReceiveRequest extends TCPMessageReceiveRequest {
     @JsonProperty("user_id")
     private String userId;
-//    @JsonProperty("room_id")
-//    private Long roomId;
-//    @JsonProperty("session")
-//    private String session;
     @JsonProperty("type")
     private String type;
+    @JsonProperty("study_time")
+    private String studyTime;
     @Override
     public String toString(){
         ObjectMapper mapper = new ObjectMapper();
@@ -33,3 +29,4 @@ public class TCPAuthRequest extends TCPMessageRequest{
         }
     }
 }
+

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/send/TCPRoomSendRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/send/TCPRoomSendRequest.java
@@ -1,11 +1,11 @@
-package pnu.cse.studyhub.state.dto.request;
+package pnu.cse.studyhub.state.dto.request.send;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 
 @Builder
-public class TCPRoomRequest {
+public class TCPRoomSendRequest {
     @JsonProperty("server")
     private String server;
     @JsonProperty("user_id")

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/send/TCPSignalingSendRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/send/TCPSignalingSendRequest.java
@@ -1,0 +1,24 @@
+package pnu.cse.studyhub.state.dto.request.send;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TCPSignalingSendRequest {
+    @JsonProperty("server")
+    private String server;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("room_id")
+    private Long roomId;
+    @JsonProperty("alert_count")
+    private Long alertCount;
+}
+

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/response/receive/TCPAuthReceiveResponse.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/response/receive/TCPAuthReceiveResponse.java
@@ -1,4 +1,4 @@
-package pnu.cse.studyhub.state.dto.response;
+package pnu.cse.studyhub.state.dto.response.receive;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class TCPSignalingResponse {
+public class TCPAuthReceiveResponse {
     @JsonProperty("user_id")
     private String userId;
     @JsonProperty("study_time")

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/response/receive/TCPSignalingReceiveResponse.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/response/receive/TCPSignalingReceiveResponse.java
@@ -1,17 +1,14 @@
-package pnu.cse.studyhub.state.dto.response;
+package pnu.cse.studyhub.state.dto.response.receive;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import pnu.cse.studyhub.state.dto.UserStudyTime;
-
-import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class TCPAuthResponse {
+public class TCPSignalingReceiveResponse {
     @JsonProperty("user_id")
     private String userId;
     @JsonProperty("study_time")

--- a/state/src/main/java/pnu/cse/studyhub/state/dto/response/send/TCPRoomSendResponse.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/response/send/TCPRoomSendResponse.java
@@ -1,0 +1,17 @@
+package pnu.cse.studyhub.state.dto.response.send;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+
+@Builder
+public class TCPRoomSendResponse {
+    @JsonProperty("server")
+    private String server;
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("room_id")
+    private Long roomId;
+//    @JsonProperty("type")
+//    private String type;
+}

--- a/state/src/main/resources/application.yml
+++ b/state/src/main/resources/application.yml
@@ -18,7 +18,12 @@ tcp:
     host : localhost
     port : 8089
     connection :
-      poolSize : 30
+      poolSize : 10
+  signaling:
+    host : localhost
+    port : 8058
+    connection :
+      poolSize : 10
 logging:
   level:
     pnu.cse.studyhub: DEBUG


### PR DESCRIPTION
## 개요
- Resolve #96 

## 작업사항
- application.yml에 시그널링서버 tcp 8058 포트 추가
- TCP Signaling Client Gateway/Config 추가
- Room 서버에서 방 관련 메세지 수신 request 구현
- Signaling 서버에 방 관련 메세지 송신 request 구현
- Room 서버에서 방 관련 메시지 수신 시, server를 state로 바꾼 후 Signaling 서버에 전달 (WebRTC 연결 해제 및 클라이언트에게 알림)

## 변경로직(optional)
- DTO 이름 명확하도록 변경
  - 메세지를 보내는 경우 send
  - 메세지를 받는 경우 receive
  - 이에 대한 요청의 경우 request
  - 이에 대한 응답의 경우 response 로 수정
- TCP Client Gateway/Config -> TCP Room Client Gateway/Config로 수정