### PR TITLE
Feat : 방장이 나갔을 때, 방 폭파 대신 방장 위임으로 수정

### DIFF
--- a/room/src/main/java/pnu/cse/studyhub/room/dto/request/tcp/TCPStateRequest.java
+++ b/room/src/main/java/pnu/cse/studyhub/room/dto/request/tcp/TCPStateRequest.java
@@ -17,10 +17,6 @@ public class TCPStateRequest extends TCPMessageRequest{
     private String userId;
     @JsonProperty("room_id")
     private Long roomId;
-//    @JsonProperty("session")
-//    private String session;
-    @JsonProperty("type")
-    private String type;
 
     @Override
     public String toString(){

--- a/room/src/main/java/pnu/cse/studyhub/room/model/entity/OpenRoomEntity.java
+++ b/room/src/main/java/pnu/cse/studyhub/room/model/entity/OpenRoomEntity.java
@@ -85,8 +85,9 @@ public class OpenRoomEntity {
         this.curUser++;
         //this.setCurUser(this.getCurUser()+1);
     }
-    public void minusUser(){
+    public int minusUser(){
         this.curUser--;
+        return this.curUser;
     }
 
 

--- a/room/src/main/java/pnu/cse/studyhub/room/model/entity/OpenUserRoomEntity.java
+++ b/room/src/main/java/pnu/cse/studyhub/room/model/entity/OpenUserRoomEntity.java
@@ -38,6 +38,8 @@ public class OpenUserRoomEntity implements UserRoom{
     private Timestamp createdAt;
     private Timestamp accessedAt;
 
+    private Timestamp leftAt;
+
     @PrePersist
     void createdAt(){
         this.createdAt = Timestamp.from(Instant.now());

--- a/room/src/main/java/pnu/cse/studyhub/room/repository/UserRoomRepository.java
+++ b/room/src/main/java/pnu/cse/studyhub/room/repository/UserRoomRepository.java
@@ -1,5 +1,6 @@
 package pnu.cse.studyhub.room.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +15,9 @@ public interface UserRoomRepository extends JpaRepository<OpenUserRoomEntity, Us
 
     @Query("select o from OpenUserRoomEntity o where o.roomId = :roomId And o.roomOwner = true")
     OpenUserRoomEntity findRoomOwnerByRoomId(@Param("roomId") Long roomId);
+
+    @Query("SELECT o FROM OpenUserRoomEntity o WHERE o.roomId = :roomId And o.leftAt IS NULL ORDER BY o.accessedAt ASC")
+    List<OpenUserRoomEntity> findFastestAccessedRooms(@Param("roomId") Long roomId, Pageable pageable);
 
 }
 

--- a/room/src/main/resources/application.yml
+++ b/room/src/main/resources/application.yml
@@ -26,6 +26,7 @@ logging:
 
 jwt:
   secret-key: ${SECRET_TOKEN}
+#  secret-key: user_token
 
 # 여긴
 tcp:


### PR DESCRIPTION
## 개요
- #98 

## 작업사항
- 일반 유저 또는 방장이 방을 나가서 상태관리서버로 부터 TCP 요청이오면 방인원 수 감소하고 방 인원이 0명이면 방을 삭제하도록 구현
- 일반 유저 나가면 해당 userRoom에 leftAt에 기록
- 방장이 나가면 현재 방에 남아있는 유저중에 accessAt이 가장 빠른 유저로 방장을 위임하고 상태관리서버로 응답을 보내줌

## 변경로직(optional)
- 방장이 방을 나가면 방폭파시키는 것 대신, 남아 있는 유저중 가장 먼저 들어온 유저를 골라 방장위임을 하는 식으로 수정하였습니다.
