### PR TITLE
Test : 상태관리서버 <-> 유저 서버 TCP 통신 테스트

### DIFF
--- a/state/src/main/java/pnu/cse/studyhub/state/service/MessageService.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/service/MessageService.java
@@ -101,7 +101,7 @@ public class MessageService {
                     TCPAuthReceiveRequest authRequest = (TCPAuthReceiveRequest) response;
                     log.warn(authRequest.toString());
                     // 유저 서버에 공부 시간 전달
-                    if (authRequest.getType().matches("USER_STUDY_TIME")) {
+                    if (authRequest.getType().matches("STUDY_TIME_FROM_TCP")) {
                         try {
                             RealTimeData realTimeData =  redisService.findRealTimeData(authRequest.getUserId());
                             if (realTimeData != null) {

--- a/state/src/main/java/pnu/cse/studyhub/state/service/MessageService.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/service/MessageService.java
@@ -107,8 +107,11 @@ public class MessageService {
                             if (realTimeData != null) {
                                 responseMessage = sendAuthServerStudyTimeMessage(realTimeData);
                             } else {
-                                //예외처리
+                                realTimeData = new RealTimeData();
+                                realTimeData.setUserId(authRequest.getUserId());
+                                responseMessage = sendAuthServerStudyTimeMessage(realTimeData);
                             }
+
                         }catch (Exception e) {
                             throw new RuntimeException(e);
                         }

--- a/state/src/test/java/pnu/cse/studyhub/state/RedisServiceTest.java
+++ b/state/src/test/java/pnu/cse/studyhub/state/RedisServiceTest.java
@@ -43,31 +43,28 @@ class RedisServiceTest {
         realTimeData2.setStudyTime(TEST_STUDYTIME2);
 
         // Clear any existing data in Redis before each test
-        redisService.setData(realTimeData);
-        redisService.setData(realTimeData2);
+        redisService.saveRealTimeData(realTimeData);
+        redisService.saveRealTimeData(realTimeData2);
     }
-    @AfterEach
-    void tearDown() {
-        // Clear any existing data in Redis after each test
-        redisService.delData(TEST_ID);
-        redisService.delData(TEST_ID2);
-    }
+//    @AfterEach
+//    void tearDown() {
+//        // Clear any existing data in Redis after each test
+//        redisService.delData(TEST_ID);
+//        redisService.delData(TEST_ID2);
+//    }
 
     @Test
     void getDataTest() {
         // Call the setValues method
-        RealTimeData savedData = redisService.getData(TEST_ID);
+        RealTimeData savedData = redisService.findRealTimeData(TEST_ID);
         Assertions.assertEquals(TEST_SESSION, savedData.getSessionId());
         System.out.println(savedData);
     }
     @Test
     void getDataListTest(){
-        List<String> ids = List.of(TEST_ID, TEST_ID2);
-        System.out.println(ids);
-        List<RealTimeData> savedData = redisService.getRealTimeData(ids);
-        System.out.println(savedData.get(0));
+        RealTimeData savedData = redisService.findRealTimeData(TEST_ID);
         System.out.println(savedData);
-        Assertions.assertEquals(TEST_SESSION, savedData.get(0).getSessionId());
+        Assertions.assertEquals(TEST_SESSION, savedData.getSessionId());
 
     }
 

--- a/state/src/test/java/pnu/cse/studyhub/state/TCPClientTest.java
+++ b/state/src/test/java/pnu/cse/studyhub/state/TCPClientTest.java
@@ -1,0 +1,74 @@
+package pnu.cse.studyhub.state;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import pnu.cse.studyhub.state.config.TCPRoomClientGateway;
+import pnu.cse.studyhub.state.config.TCPSignalingClientGateway;
+import pnu.cse.studyhub.state.dto.request.send.TCPSignalingSendRequest;
+import pnu.cse.studyhub.state.repository.entity.RealTimeData;
+import pnu.cse.studyhub.state.service.MessageService;
+import pnu.cse.studyhub.state.service.RedisService;
+
+@SpringBootTest
+public class TCPClientTest {
+
+    @Autowired
+    private TCPRoomClientGateway tcpRoomClientGateway;
+    @Autowired
+    private TCPSignalingClientGateway tcpSignalingClientGateway;
+    @Autowired
+    private MessageService messageService;
+    @Autowired
+    private RedisService redisService;
+
+    @Test
+    public void testSendRoomServerRoomOutMessage() {
+        RealTimeData rtData = new RealTimeData();
+        rtData.setUserId("user123");
+        rtData.setRoomId(1L);
+
+        try {
+            String messageResponse = messageService.sendRoomServerRoomOutMessage(rtData);
+            tcpRoomClientGateway.send(messageResponse);
+            System.out.println("Response Message: " + messageResponse);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    @Test
+    public void testSendSignalingServerRoomMessage() {
+        TCPSignalingSendRequest testRequest =  TCPSignalingSendRequest.builder()
+                .server("state")
+                .type("ALERT")
+                .userId("jeho")
+                .roomId(999L)
+                .alertCount(1L)
+                .build();
+        try {
+            String messageResponse = messageService.sendSignalingServerRoomMessage(testRequest);
+            tcpSignalingClientGateway.send(messageResponse);
+            System.out.println("Response Message: " + messageResponse);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    @Test
+    public void testSamples() {
+        RealTimeData rtData = new RealTimeData();
+        rtData.setSessionId("abcd");
+        rtData.setStudyTime(null);
+        rtData.setRoomId(null);
+        rtData.setUserId("user123");
+        rtData.setRoomId(1L);
+
+        try {
+            redisService.saveRealTimeData(rtData);
+            System.out.println("Response Message: " + rtData);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
## 개요
- Resolve #92 

## 작업사항
- USER_STUDY_TIME -> STUDY_TIME_FROM_TCP로 코드 통일
- Redis BeforeEach문 작성 -> redis 테스트용 데이터 삽입

## 변경로직(optional)
- redis에 저장된 실시간 정보가 없을 경우 객체를 생성하여 반환