### PR TITLE
Fix : TCP Request 타입 변환 시 .type 속성 오류 수정

### DIFF
--- a/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPRoomReceiveRequest.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/dto/request/receive/TCPRoomReceiveRequest.java
@@ -23,19 +23,19 @@ public class TCPRoomReceiveRequest extends TCPMessageReceiveRequest {
     @JsonProperty("alert_count")
     private Long alertCount;
 
-    public TCPSignalingSendAlertRequest toTCPSignalingSendAlertRequest() {
+    public TCPSignalingSendAlertRequest toTCPSignalingSendAlertRequest(String type) {
         return TCPSignalingSendAlertRequest.builder()
                 .server("state")
-                .type(super.getType())
+                .type(type)
                 .userId(this.userId)
                 .roomId(this.roomId)
                 .alertCount(this.alertCount)
                 .build();
     }
-    public TCPSignalingSendRequest toTCPSignalingSendRequest() {
+    public TCPSignalingSendRequest toTCPSignalingSendRequest(String type) {
         return TCPSignalingSendRequest.builder()
                 .server("state")
-                .type(super.getType())
+                .type(type)
                 .userId(this.userId)
                 .roomId(this.roomId)
                 .build();

--- a/state/src/main/java/pnu/cse/studyhub/state/service/MessageService.java
+++ b/state/src/main/java/pnu/cse/studyhub/state/service/MessageService.java
@@ -228,12 +228,12 @@ public class MessageService {
         return tcpAuthResponseMessage;
     }
     public String sendSignalingServerRoomMessage(TCPRoomReceiveRequest tcpRoomReceiveRequest){
-        TCPSignalingSendRequest tcpSignalingSendRequest = tcpRoomReceiveRequest.toTCPSignalingSendRequest();
+        TCPSignalingSendRequest tcpSignalingSendRequest = tcpRoomReceiveRequest.toTCPSignalingSendRequest(tcpRoomReceiveRequest.getType());
         String tcpSignalingSendRequestMessage = jsonConverter.convertToJson(tcpSignalingSendRequest);
         return tcpSignalingSendRequestMessage;
     }
     public String sendSignalingServerAlertMessage(TCPRoomReceiveRequest tcpRoomReceiveRequest) {
-        TCPSignalingSendAlertRequest tcpSignalingSendRequest = tcpRoomReceiveRequest.toTCPSignalingSendAlertRequest();
+        TCPSignalingSendAlertRequest tcpSignalingSendRequest = tcpRoomReceiveRequest.toTCPSignalingSendAlertRequest(tcpRoomReceiveRequest.getType());
         String tcpSignalingSendRequestMessage = jsonConverter.convertToJson(tcpSignalingSendRequest);
         return tcpSignalingSendRequestMessage;
     }


### PR DESCRIPTION


## 개요
- TCP Request 타입 변환 시 .type 속성 오류 수정
## 작업사항
- TCPSignalingSendAlertRequest 의 인자를 받아 .type 속성에 입력하도록 구현
- TCPSignalingSendRequest 의 인자를 받아 .type 속성에 입력하도록 구현

