### PR TITLE
Refactor : Interceptor 클래스의 TCP 로직 제거 / TCPMessageService로 이동

### DIFF
--- a/chat/src/main/java/pnu/cse/studyhub/chat/config/kafka/MessageChannelInterceptor.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/config/kafka/MessageChannelInterceptor.java
@@ -55,43 +55,13 @@ public class MessageChannelInterceptor implements ChannelInterceptor {
         switch (accessor.getCommand()) {
             case SUBSCRIBE: // room ID에 들어갈 때(소켓 연결이 아니라 채팅방에 들어갈 때 )
                 userId = getUserId(authorizationHeader);
-                Long roomId = Long.valueOf(accessor.getDestination().substring(7));
-//                log.info(roomId.toString());
-//                TCPSocketSessionRequest subscribeRequest = TCPSocketSessionRequest.builder()
-//                        .type("SUBSCRIBE")
-//                        // "Timer ON TIMER OFF 프론트에서 보내는ㅅ거, USER_OUT, USER_IN 프론트에서 받는거
-//                        .userId(userId)
-//                        .server("chat")
-//                        .roomId(roomId) // 슬래쉬 ( '/topic/' ) 삭제
-//                        .session(sessionId)
-//                        .build();
-//                log.debug(accessor.getCommand() + " : " + subscribeRequest.toString());
-//                tcpMessageService.sendMessage(subscribeRequest.toString());
+                Long roomId = Long.valueOf(accessor.getDestination().substring(7)); // 슬래쉬 ( '/topic/' ) 삭제
+                tcpMessageService.subscribeRoom(roomId, userId, sessionId);
                 grpcClientService.subscribeRoom(userId,roomId,sessionId);
                 break;
-            case DISCONNECT: // 채팅방 나갈 때
-//                TCPSocketSessionRequest disconnectRequest = TCPSocketSessionRequest.builder()
-//                        .type("DISCONNECT")
-//                        .userId(userId)
-//                        .server("chat")
-//                        .roomId(null) // 슬래쉬 ( '/topic/' ) 삭제
-//                        .session(sessionId)
-//                        .build();
-//                log.debug(accessor.getCommand() + " : " + disconnectRequest.toString());
-//                tcpMessageService.sendMessage(disconnectRequest.toString());
-                grpcClientService.unsubscribeRoom(sessionId);
-                break;
-            case UNSUBSCRIBE:
-//                userId = getUserId(authorizationHeader);
-//                TCPSocketSessionRequest unsubscribeRequest = TCPSocketSessionRequest.builder()
-//                        .type("UNSUBSCRIBE")
-//                        .userId(userId)
-//                        .server("chat")
-//                        .roomId(null) // 슬래쉬 ( '/topic/' ) 삭제
-//                        .session(sessionId)
-//                        .build();
-//                log.debug(accessor.getCommand() + " : " + unsubscribeRequest.toString());
-//                tcpMessageService.sendMessage(unsubscribeRequest.toString());
+            case UNSUBSCRIBE: // 채팅방 나갈 때 (UNSUBSCRIBE || DISCONNECT)
+            case DISCONNECT:
+                tcpMessageService.unsubscribeRoom(userId,sessionId);
                 grpcClientService.unsubscribeRoom(sessionId);
                 break;
         }
@@ -111,7 +81,4 @@ public class MessageChannelInterceptor implements ChannelInterceptor {
     public void afterReceiveCompletion(Message<?> message, MessageChannel channel, Exception ex) {
         ChannelInterceptor.super.afterReceiveCompletion(message, channel, ex);
     }
-
-
-
 }

--- a/chat/src/main/java/pnu/cse/studyhub/chat/config/tcp/TCPMessageService.java
+++ b/chat/src/main/java/pnu/cse/studyhub/chat/config/tcp/TCPMessageService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Jwt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import pnu.cse.studyhub.chat.dto.request.TCPSocketSessionRequest;
 import pnu.cse.studyhub.chat.util.ByteArrayToStringConverter;
 
 
@@ -14,7 +15,31 @@ public class TCPMessageService {
     private final TCPClientGateway tcpClientGateway;
     private final ByteArrayToStringConverter converter;
 
-    public void sendMessage(String message) {
+    //subscribe
+    public void subscribeRoom(Long roomId, String userId, String sessionId) {
+        TCPSocketSessionRequest subscribeRequest = TCPSocketSessionRequest.builder()
+                .type("SUBSCRIBE")
+                .userId(userId)
+                .server("chat")
+                .roomId(roomId)
+                .session(sessionId)
+                .build();
+        String message = subscribeRequest.toString();
+        log.debug("Sending message: {}", message);
+        String byteResponse = tcpClientGateway.send(message);
+        String strResponse = converter.convert(byteResponse);
+        log.debug("Received response: {}", strResponse);
+    }
+    //unsubscribe || disconnect
+    public void unsubscribeRoom(String userId, String sessionId) {
+        TCPSocketSessionRequest unsubscribeRequest = TCPSocketSessionRequest.builder()
+                .type("UNSUBSCRIBE")
+                .userId(userId)
+                .server("chat")
+                .roomId(null)
+                .session(sessionId)
+                .build();
+        String message = unsubscribeRequest.toString();
         log.debug("Sending message: {}", message);
         String byteResponse = tcpClientGateway.send(message);
         String strResponse = converter.convert(byteResponse);


### PR DESCRIPTION
## 개요
- Interceptor 클래스에 TCP 코드가 길다고 판단

## 작업사항
- Interceptor 클래스 TCP 로직 제거
- 구독 및 구독 해제를 위한 메세지 전송 주요 로직이므로 TCPMessageService 클래스로 이동

## 변경로직(optional)
- 이전 방식 : Interceptor 클래스에서 switch 문을 통해 조건에 따라 String Message 형태로 변환 -> 이후 sendMessage 함수 호출
- 새로운 방식 : Interceptor 클래스에서 세션 정보, 유저 정보를 함수로 전달 , 
                      추가적으로 sendMessage 함수를 gRPC 함수와 동일한 함수 형태로 변경
    - subscribeRoom(Long roomId, String userId, String sessionId)
    - unsubscribeRoom(String userId, String sessionId)
